### PR TITLE
Set product special price via catalog staging from extension attribute

### DIFF
--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SnowIO\ExtendedProductRepositoryEE\Plugin\Model;
+
+use SnowIO\ExtendedProductRepository\Model\ProductDataMapper;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\Data\ProductExtensionInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use Magento\Catalog\Api\Data\SpecialPriceInterface;
+use Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice;
+
+class ProductDataMapperPlugin
+{
+    /** @var SpecialPrice  */
+    private $stagingSpecialPriceModel;
+
+    /**
+     * ProductDataMapperPlugin constructor.
+     * @param SpecialPrice $stagingSpecialPriceModel
+     */
+    public function __construct(SpecialPrice $stagingSpecialPriceModel)
+    {
+        $this->stagingSpecialPriceModel = $stagingSpecialPriceModel;
+    }
+
+    /**
+     * @author Liam Toohey (lt@amp.co)
+     * @param ProductDataMapper $subject
+     * @param \Closure $proceed
+     * @param ProductInterface $product
+     * @return mixed|void
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    public function aroundMapProductDataForSave(ProductDataMapper $subject, \Closure $proceed, ProductInterface $product)
+    {
+        /**
+         * Original function has no return value.
+         */
+        $proceed($product);
+
+        if (!$extensionAttributes = $product->getExtensionAttributes()) {
+            return;
+        }
+
+        $this->mapProductSpecialPrices($extensionAttributes);
+    }
+
+    /**
+     * @author Liam Toohey (lt@amp.co)
+     * @param ProductExtensionInterface $extensionAttributes
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    private function mapProductSpecialPrices(ProductExtensionInterface $extensionAttributes)
+    {
+        if (null === $prices = $extensionAttributes->getSpecialPrice()) {
+            return;
+        }
+
+        foreach ($prices as $price) {
+            if (!$this->validatePricePayload($price)) {
+                throw new LocalizedException(new Phrase(
+                    'Missing data from special_price extension attribute payload'
+                ));
+            }
+        }
+        /**
+         * $prices = [
+         *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
+         *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
+         *     ...
+         * ]
+         */
+        $this->stagingSpecialPriceModel->update($prices);
+    }
+
+    /**
+     * @author Liam Toohey (lt@amp.co)
+     * @param SpecialPriceInterface $price
+     * @return bool
+     */
+    private function validatePricePayload(SpecialPriceInterface $price)
+    {
+        if (
+            !$price->getPrice() ||
+            !$price->getStoreId() ||
+            !$price->getSku() ||
+            !$price->getPriceFrom() ||
+            !$price->getPriceTo()
+        ) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace SnowIO\ExtendedProductRepositoryEE\Test\Unit\Plugin\Model;
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Api\Data\ProductExtensionInterface;
+use MiniSpares\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin as Plugin;
+use SnowIO\ExtendedProductRepository\Model\ProductDataMapper;
+use Magento\Catalog\Api\Data\SpecialPriceInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice;
+
+class ProductDataMapperPluginTest extends TestCase
+{
+    private $product;
+    private $extensionAttributes;
+    private $specialPrice;
+    private $subject;
+    private $plugin;
+    private $stagingSpecialPriceModel;
+
+    protected function setUp()
+    {
+        $om = new ObjectManager($this);
+
+        $this->product = $this
+            ->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->extensionAttributes = $this
+            ->getMockBuilder(ProductExtensionInterface::class)
+            ->setMethods(['getSpecialPrice'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->specialPrice = $this
+            ->getMockBuilder(SpecialPriceInterface::class)
+            ->setMethods([
+                'setPrice',
+                'setStoreId',
+                'setSku',
+                'setPriceFrom',
+                'setPriceTo',
+                'setExtensionAttributes',
+                'getPrice',
+                'getStoreId',
+                'getSku',
+                'getPriceFrom',
+                'getPriceTo',
+                'getExtensionAttributes'
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->stagingSpecialPriceModel = $this
+            ->getMockBuilder(SpecialPrice::class)
+            ->setMethods(['update'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /**
+         * This method is not tested (out of scope, core Magento method).
+         * If we make it to this call, the payload is valid and this function should return true.
+         */
+        $this->stagingSpecialPriceModel
+            ->expects($this->any())
+            ->method('update')
+            ->willReturn(true);
+
+        $this->subject = $om->getObject(ProductDataMapper::class);
+        $this->plugin = new Plugin($this->stagingSpecialPriceModel);
+    }
+
+    /**
+     * Test that a product with no extension attributes does nothing.
+     *
+     * @author Liam Toohey (lt@amp.co)
+     */
+    public function testMapProductDataForSaveWithoutExtensionAttributes()
+    {
+        $this->product
+            ->expects($this->any())
+            ->method('getExtensionAttributes')
+            ->willReturn(null);
+
+        $result = $this->plugin->aroundMapProductDataForSave(
+            $this->subject,
+            $this->mockProceedForPlugin(),
+            $this->product
+        );
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test that a product with extension attributes, but without special price extension attribute does nothing.
+     *
+     * @author Liam Toohey (lt@amp.co)
+     */
+    public function testMapProductDataForSaveNoSpecialPriceExtensionAttribute()
+    {
+        $this->extensionAttributes
+            ->expects($this->any())
+            ->method('getSpecialPrice')
+            ->willReturn(null);
+
+        $this->product
+            ->expects($this->any())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->extensionAttributes);
+
+        $result = $this->plugin->aroundMapProductDataForSave(
+            $this->subject,
+            $this->mockProceedForPlugin(),
+            $this->product
+        );
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test that a product with an invalid special price payload throws exception.
+     *
+     * @author Liam Toohey (lt@amp.co)
+     */
+    public function testMapProductDataForSaveInvalidPayload()
+    {
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getPrice')
+            ->willReturn(null);
+
+        $this->extensionAttributes
+            ->expects($this->any())
+            ->method('getSpecialPrice')
+            ->willReturn([$this->specialPrice]);
+
+        $this->product
+            ->expects($this->any())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->extensionAttributes);
+
+        $this->expectException(LocalizedException::class);
+
+        $this->plugin->aroundMapProductDataForSave(
+            $this->subject,
+            $this->mockProceedForPlugin(),
+            $this->product
+        );
+    }
+
+    /**
+     * Test that a product valid special price payload returns true (success).
+     *
+     * @author Liam Toohey (lt@amp.co)
+     */
+    public function testMapProductDataForSaveValidPayload()
+    {
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getPrice')
+            ->willReturn(10.00);
+
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getStoreId')
+            ->willReturn(1);
+
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getSku')
+            ->willReturn('SKUTEST');
+
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getPriceFrom')
+            ->willReturn('2018-12-12 13:48:05');
+
+        $this->specialPrice
+            ->expects($this->any())
+            ->method('getPriceTo')
+            ->willReturn('2018-12-19 00:00:00');
+
+        $this->extensionAttributes
+            ->expects($this->any())
+            ->method('getSpecialPrice')
+            ->willReturn([$this->specialPrice]);
+
+        $this->product
+            ->expects($this->any())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->extensionAttributes);
+
+        $result = $this->plugin->aroundMapProductDataForSave(
+            $this->subject,
+            $this->mockProceedForPlugin(),
+            $this->product
+        );
+
+        $this->assertEquals(null, $result);
+    }
+
+    /**
+     * @author Liam Toohey (lt@amp.co)
+     * @return \Closure
+     */
+    protected function mockProceedForPlugin(): \Closure
+    {
+        /**
+         * Mock closure for method call.
+         */
+        $callbackMock = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
+        $closure = function () use ($callbackMock) {
+            return $callbackMock();
+        };
+        return $closure;
+    }
+}

--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -153,7 +153,7 @@ class ProductDataMapperPluginTest extends TestCase
     }
 
     /**
-     * Test that a product valid special price payload returns true (success).
+     * Test that a product valid special price payload returns null (void method).
      *
      * @author Liam Toohey (lt@amp.co)
      */
@@ -200,6 +200,9 @@ class ProductDataMapperPluginTest extends TestCase
             $this->product
         );
 
+        /**
+         * Successful calls to aroundMapProductDataForSave return void.
+         */
         $this->assertEquals(null, $result);
     }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="SnowIO\ExtendedProductRepository\Model\ProductDataMapper">
+        <plugin name="ExtendedProductRepositoryDataMapperPlugin" type="SnowIO\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin" disabled="false"/>
+    </type>
+</config>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,0 +1,4 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd"><extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
+        <attribute code="special_price" type="Magento\Catalog\Api\Data\SpecialPriceInterface[]" />
+    </extension_attributes>
+</config>


### PR DESCRIPTION
Set special price to product from extension attribute
-----------------

This PR aims to ensure special prices can be set for products using the EE specific catalog staging module - via the `rest/V1/products-with-option-codes` endpoint.

Extension attribute payload for `rest/V1/products-with-option-codes/SKU-HERE` with special price info: 

```
            "extension_attributes": {
                "special_price": [{
			    	"price": "7.65",
			    	"store_id": "1",
				    "sku": "BMP124",
				    "price_from": "2018-12-04 13:48:05",
				    "price_to": "2018-12-07 00:00:00"
                },{
			    	"price": "10.65",
			    	"store_id": "1",
				    "sku": "BMP124",
				    "price_from": "2018-12-12 13:48:05",
				    "price_to": "2018-12-19 00:00:00"
                }]
            },
```

**Results (At the top of admin product edit page):**

![image](https://user-images.githubusercontent.com/22290866/47798053-7d41f780-dd1f-11e8-97bd-3c3118a532d5.png)