### PR TITLE
Load store id from store code in payload

### DIFF
--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase as TestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
-use MiniSpares\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin as Plugin;
+use SnowIO\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin as Plugin;
 use SnowIO\ExtendedProductRepository\Model\ProductDataMapper;
 use Magento\Catalog\Api\Data\SpecialPriceInterface;
 use Magento\Framework\Exception\LocalizedException;


### PR DESCRIPTION
Load store id from store code in payload
-----------------

We only have access to the store code in mapping. We have to name this store_id in order for the extension attribute declaration to implement `Magento\Catalog\Api\Data\SpecialPriceInterface`.