### PR TITLE
Amend plugin to accept both integer and string from store_id payload

### DIFF
--- a/Api/Data/SpecialPriceMappingInterface.php
+++ b/Api/Data/SpecialPriceMappingInterface.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace SnowIO\ExtendedProductRepositoryEE\Api\Data;
+
+/**
+ * @author Liam Toohey (lt@amp.co)
+ * Interface SpecialPriceMappingInterface
+ * @package SnowIO\ExtendedProductRepositoryEE\Api\Data
+ */
+interface SpecialPriceMappingInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+{
+    /**#@+
+     * Constants
+     */
+    const PRICE = 'price';
+    const STORE_ID = 'store_id';
+    const SKU = 'sku';
+    const PRICE_FROM = 'price_from';
+    const PRICE_TO = 'price_to';
+    /**#@-*/
+
+    /**
+     * Set product special price value.
+     *
+     * @param float $price
+     * @return $this
+     */
+    public function setPrice($price);
+
+    /**
+     * Get product special price value.
+     *
+     * @return float
+     */
+    public function getPrice();
+
+    /**
+     * Set ID of store, that contains special price value.
+     *
+     * @param string $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId);
+
+    /**
+     * Get ID of store, that contains special price value.
+     *
+     * @return string
+     */
+    public function getStoreId();
+
+    /**
+     * Set SKU of product, that contains special price value.
+     *
+     * @param string $sku
+     * @return $this
+     */
+    public function setSku($sku);
+
+    /**
+     * Get SKU of product, that contains special price value.
+     *
+     * @return string
+     */
+    public function getSku();
+
+    /**
+     * Set start date for special price in Y-m-d H:i:s format.
+     *
+     * @param string $datetime
+     * @return $this
+     */
+    public function setPriceFrom($datetime);
+
+    /**
+     * Get start date for special price in Y-m-d H:i:s format.
+     *
+     * @return string
+     */
+    public function getPriceFrom();
+
+    /**
+     * Set end date for special price in Y-m-d H:i:s format.
+     *
+     * @param string $datetime
+     * @return $this
+     */
+    public function setPriceTo($datetime);
+
+    /**
+     * Get end date for special price in Y-m-d H:i:s format.
+     *
+     * @return string
+     */
+    public function getPriceTo();
+
+    /**
+     * Retrieve existing extension attributes object.
+     * If extension attributes do not exist return null.
+     *
+     * @return \Magento\Catalog\Api\Data\SpecialPriceExtensionInterface|null
+     */
+    public function getExtensionAttributes();
+
+    /**
+     * Set an extension attributes object.
+     *
+     * @param \Magento\Catalog\Api\Data\SpecialPriceExtensionInterface $extensionAttributes
+     * @return $this
+     */
+    public function setExtensionAttributes(
+        \Magento\Catalog\Api\Data\SpecialPriceExtensionInterface $extensionAttributes
+    );
+}

--- a/Model/SpecialPriceMapping.php
+++ b/Model/SpecialPriceMapping.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SnowIO\ExtendedProductRepositoryEE\Model;
+
+use SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface;
+
+/**
+ * Product Special Price class is used to encapsulate data that can be processed by efficient price API.
+ */
+class SpecialPriceMapping extends \Magento\Framework\Model\AbstractExtensibleModel implements SpecialPriceMappingInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setPrice($price)
+    {
+        return $this->setData(self::PRICE, $price);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrice()
+    {
+        return $this->getData(self::PRICE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStoreId($storeId)
+    {
+        return $this->setData(self::STORE_ID, $storeId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStoreId()
+    {
+        return $this->getData(self::STORE_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSku($sku)
+    {
+        return $this->setData(self::SKU, $sku);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSku()
+    {
+        return $this->getData(self::SKU);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriceFrom($datetime)
+    {
+        return $this->setData(self::PRICE_FROM, $datetime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriceFrom()
+    {
+        return $this->getData(self::PRICE_FROM);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriceTo($datetime)
+    {
+        return $this->setData(self::PRICE_TO, $datetime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriceTo()
+    {
+        return $this->getData(self::PRICE_TO);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtensionAttributes()
+    {
+        return $this->_getExtensionAttributes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtensionAttributes(
+        \Magento\Catalog\Api\Data\SpecialPriceExtensionInterface $extensionAttributes
+    ) {
+        return $this->_setExtensionAttributes($extensionAttributes);
+    }
+}

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -98,9 +98,10 @@ class ProductDataMapperPlugin
                 $price->setStoreId($store->getId());
             }
             /**
-             * We now need to transform SpecialPriceMappingInterface into vanilla SpecialPriceInterface.
-             * This is to ensure vanilla update functionality works.
+             * SpecialPriceMappingInterface will not be accepted in the vanilla functions used to update special prices.
+             * We need to create vanilla SpecialPriceInterface instances from our SpecialPriceMappingInterface data.
              *
+             * Example of SpecialPriceInterface instance being required in vanilla functionality:
              * @see \Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice::priceSelectionsAreEqual
              */
             $specialPriceClone = clone $this->specialPrice;

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -116,14 +116,16 @@ class ProductDataMapperPlugin
                 ->setPriceTo($price->getPriceTo());
         }
 
-        /**
-         * $specialPrices = [
-         *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
-         *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
-         *     ...
-         * ]
-         */
-        $this->stagingSpecialPriceModel->update($specialPrices);
+        if (!empty($specialPrices)) {
+            /**
+             * $specialPrices = [
+             *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
+             *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
+             *     ...
+             * ]
+             */
+            $this->stagingSpecialPriceModel->update($specialPrices);
+        }
     }
 
     /**

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -7,9 +7,11 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
-use Magento\Catalog\Api\Data\SpecialPriceInterface;
+use SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface;
 use Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice;
 use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Catalog\Api\Data\SpecialPriceInterface;
 
 class ProductDataMapperPlugin
 {
@@ -17,6 +19,8 @@ class ProductDataMapperPlugin
     private $stagingSpecialPriceModel;
     /** @var StoreRepositoryInterface  */
     private $storeRepository;
+    /** @var SpecialPriceInterface  */
+    private $specialPrice;
 
     /**
      * ProductDataMapperPlugin constructor.
@@ -25,11 +29,13 @@ class ProductDataMapperPlugin
      */
     public function __construct(
         SpecialPrice $stagingSpecialPriceModel,
-        StoreRepositoryInterface $storeRepository
+        StoreRepositoryInterface $storeRepository,
+        SpecialPriceInterface $specialPrice
     )
     {
         $this->stagingSpecialPriceModel = $stagingSpecialPriceModel;
         $this->storeRepository = $storeRepository;
+        $this->specialPrice = $specialPrice;
     }
 
     /**
@@ -67,6 +73,10 @@ class ProductDataMapperPlugin
             return;
         }
 
+        $specialPrices = [];
+        $specialPriceClone = clone $this->specialPrice;
+        
+        /** @var \SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface $price */
         foreach ($prices as $price) {
             if (!$this->validatePricePayload($price)) {
                 throw new LocalizedException(new Phrase(
@@ -75,32 +85,52 @@ class ProductDataMapperPlugin
             }
 
             /**
-             * $price->getStoreId() === store code, not the ID.
+             * IMPORTANT:
+             *
+             * In most cases, $price->getStoreId() === store code, not the ID.
              *
              * This is because we only have access to the store code in mapping.
-             * We have to name this store_id in order for the extension attribute
-             * declaration to implement Magento\Catalog\Api\Data\SpecialPriceInterface
+             * We have to name this store_id so the special price data model matches vanilla.
+             *
+             * @see https://github.com/snowio/magento2-data-model/blob/v0.5.10/src/SpecialPrice.php
+             *
+             * If payload does contain numeric store_id, continue.
              */
-            $store = $this->storeRepository->get($price->getStoreId());
-            $price->setStoreId($store->getId());
+            if (!is_numeric($price->getStoreId())) {
+                $store = $this->storeRepository->get($price->getStoreId());
+                $price->setStoreId($store->getId());
+            }
+
+            /**
+             * We now need to transform SpecialPriceMappingInterface into vanilla SpecialPriceInterface.
+             * This is to ensure vanilla update functionality works.
+             *
+             * @see \Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice::priceSelectionsAreEqual
+             */
+            $specialPrices[] = $specialPriceClone
+                ->setPrice($price->getPrice())
+                ->setStoreId($price->getStoreId())
+                ->setSku($price->getSku())
+                ->setPriceFrom($price->getPriceFrom())
+                ->setPriceTo($price->getPriceTo());
         }
 
         /**
-         * $prices = [
+         * $specialPrices = [
          *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
          *     \Magento\Catalog\Api\Data\SpecialPriceInterface,
          *     ...
          * ]
          */
-        $this->stagingSpecialPriceModel->update($prices);
+        $this->stagingSpecialPriceModel->update($specialPrices);
     }
 
     /**
      * @author Liam Toohey (lt@amp.co)
-     * @param SpecialPriceInterface $price
+     * @param SpecialPriceMappingInterface $price
      * @return bool
      */
-    private function validatePricePayload(SpecialPriceInterface $price)
+    private function validatePricePayload(SpecialPriceMappingInterface $price)
     {
         if (
             !$price->getPrice() ||

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -74,8 +74,6 @@ class ProductDataMapperPlugin
         }
 
         $specialPrices = [];
-        $specialPriceClone = clone $this->specialPrice;
-        
         /** @var \SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface $price */
         foreach ($prices as $price) {
             if (!$this->validatePricePayload($price)) {
@@ -83,7 +81,6 @@ class ProductDataMapperPlugin
                     'Missing data from special_price extension attribute payload'
                 ));
             }
-
             /**
              * IMPORTANT:
              *
@@ -100,13 +97,13 @@ class ProductDataMapperPlugin
                 $store = $this->storeRepository->get($price->getStoreId());
                 $price->setStoreId($store->getId());
             }
-
             /**
              * We now need to transform SpecialPriceMappingInterface into vanilla SpecialPriceInterface.
              * This is to ensure vanilla update functionality works.
              *
              * @see \Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice::priceSelectionsAreEqual
              */
+            $specialPriceClone = clone $this->specialPrice;
             $specialPrices[] = $specialPriceClone
                 ->setPrice($price->getPrice())
                 ->setStoreId($price->getStoreId())

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -80,6 +80,9 @@ class ProductDataMapperPlugin
                 throw new LocalizedException(new Phrase(
                     'Missing data from special_price extension attribute payload'
                 ));
+            } elseif (strtotime($price->getPriceFrom()) < time()) {
+                // If outdated special price, ignore.
+                continue;
             }
             /**
              * IMPORTANT:

--- a/Test/Unit/Fixture/SpecialPrice.php
+++ b/Test/Unit/Fixture/SpecialPrice.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SnowIO\ExtendedProductRepositoryEE\Test\Unit\Fixture;
+
+class SpecialPrice extends \Magento\Framework\DataObject implements \Magento\Catalog\Api\Data\SpecialPriceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setPrice($price)
+    {
+        return $this->setData(self::PRICE, $price);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrice()
+    {
+        return $this->getData(self::PRICE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStoreId($storeId)
+    {
+        return $this->setData(self::STORE_ID, $storeId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStoreId()
+    {
+        return $this->getData(self::STORE_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSku($sku)
+    {
+        return $this->setData(self::SKU, $sku);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSku()
+    {
+        return $this->getData(self::SKU);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriceFrom($datetime)
+    {
+        return $this->setData(self::PRICE_FROM, $datetime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriceFrom()
+    {
+        return $this->getData(self::PRICE_FROM);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriceTo($datetime)
+    {
+        return $this->setData(self::PRICE_TO, $datetime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriceTo()
+    {
+        return $this->getData(self::PRICE_TO);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtensionAttributes()
+    {
+        return $this->_getExtensionAttributes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtensionAttributes(
+        \Magento\Catalog\Api\Data\SpecialPriceExtensionInterface $extensionAttributes
+    ) {
+        return $this->_setExtensionAttributes($extensionAttributes);
+    }
+}

--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -193,13 +193,13 @@ class ProductDataMapperPluginTest extends TestCase
         /**
          * Successful calls to aroundMapProductDataForSave return void.
          */
-        $this->assertEquals(null, $result);
+        $this->assertEquals($expected, $result);
     }
 
     public function dataForAroundMapProductDataForSave()
     {
         return [
-            'Invalid payload' => [
+            'Invalid payload - No data' => [
                 $price = null,
                 $storeId = null,
                 $actualStoreId = null,
@@ -208,25 +208,36 @@ class ProductDataMapperPluginTest extends TestCase
                 $priceTo = null,
                 $expected = LocalizedException::class
             ],
-            'Valid payload with store code' => [
+            'Invalid payload - Outdated' => [
                 $price = '10.00',
                 // Store ID will likely be store code as we only have code in mappings.
                 $storeId = 'ms_uk',
                 // This is the actual store ID loaded from Magento, using the store code.
                 $actualStoreId = '1',
                 $sku = 'TEST01',
+                $priceFrom = '2015-12-04 13:48:05',
+                $priceTo = '2015-12-07 00:00:00',
+                $expected = null
+            ],
+            'Valid payload - With store code' => [
+                $price = '10.00',
+                // Store ID will likely be store code as we only have code in mappings.
+                $storeId = 'ms_uk',
+                // This is the actual store ID loaded from Magento, using the store code.
+                $actualStoreId = '1',
+                $sku = 'TEST02',
                 $priceFrom = '2020-12-04 13:48:05',
                 $priceTo = '2020-12-07 00:00:00',
                 // Successful calls to aroundMapProductDataForSave return void.
                 $expected = null
             ],
-            'Valid payload with store id' => [
+            'Valid payload - With store id' => [
                 $price = '10.00',
                 // Also handle cases where correct store id is passed in payload.
                 $storeId = '1',
                 // Actual store ID not loaded as store ID passes in payload.
                 $actualStoreId = null,
-                $sku = 'TEST01',
+                $sku = 'TEST03',
                 $priceFrom = '2020-12-04 13:48:05',
                 $priceTo = '2020-12-07 00:00:00',
                 // Successful calls to aroundMapProductDataForSave return void.

--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -135,30 +135,7 @@ class ProductDataMapperPluginTest extends TestCase
         $expected
     )
     {
-        $this->specialPriceMapping
-            ->expects($this->any())
-            ->method('getPrice')
-            ->willReturn($price);
-
-        $this->specialPriceMapping
-            ->expects($this->any())
-            ->method('getStoreId')
-            ->willReturn($storeId);
-
-        $this->specialPriceMapping
-            ->expects($this->any())
-            ->method('getSku')
-            ->willReturn($sku);
-
-        $this->specialPriceMapping
-            ->expects($this->any())
-            ->method('getPriceFrom')
-            ->willReturn($priceFrom);
-
-        $this->specialPriceMapping
-            ->expects($this->any())
-            ->method('getPriceTo')
-            ->willReturn($priceTo);
+        $this->mockSpecialPriceMethods($price, $storeId, $sku, $priceFrom, $priceTo);
 
         $this->extensionAttributes
             ->expects($this->any())
@@ -174,7 +151,7 @@ class ProductDataMapperPluginTest extends TestCase
          * Actual store id is set from data provider if payload includes store code instead of store id.
          * We need to mock that the store id actually gets set to the special price, not the code.
          */
-        if(!is_null($actualStoreId)) {
+        if (!is_null($actualStoreId)) {
             $this->store
                 ->expects($this->any())
                 ->method('getId')
@@ -256,6 +233,42 @@ class ProductDataMapperPluginTest extends TestCase
                 $expected = null
             ],
         ];
+    }
+
+    /**
+     * @author Liam Toohey (lt@amp.co)
+     * @param $price
+     * @param $storeId
+     * @param $sku
+     * @param $priceFrom
+     * @param $priceTo
+     */
+    protected function mockSpecialPriceMethods($price, $storeId, $sku, $priceFrom, $priceTo)
+    {
+        $this->specialPriceMapping
+            ->expects($this->any())
+            ->method('getPrice')
+            ->willReturn($price);
+
+        $this->specialPriceMapping
+            ->expects($this->any())
+            ->method('getStoreId')
+            ->willReturn($storeId);
+
+        $this->specialPriceMapping
+            ->expects($this->any())
+            ->method('getSku')
+            ->willReturn($sku);
+
+        $this->specialPriceMapping
+            ->expects($this->any())
+            ->method('getPriceFrom')
+            ->willReturn($priceFrom);
+
+        $this->specialPriceMapping
+            ->expects($this->any())
+            ->method('getPriceTo')
+            ->willReturn($priceTo);
     }
 
     /**

--- a/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
+++ b/Test/Unit/Plugin/Model/ProductDataMapperPluginTest.php
@@ -6,9 +6,10 @@ use PHPUnit\Framework\TestCase as TestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
+use SnowIO\ExtendedProductRepositoryEE\Model\SpecialPriceMapping;
 use SnowIO\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin as Plugin;
 use SnowIO\ExtendedProductRepository\Model\ProductDataMapper;
-use Magento\Catalog\Api\Data\SpecialPriceInterface;
+use SnowIO\ExtendedProductRepositoryEE\Test\Unit\Fixture\SpecialPrice as SpecialPriceFixture;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\CatalogStaging\Model\ResourceModel\Product\Price\SpecialPrice;
 use Magento\Store\Model\StoreRepository;
@@ -18,6 +19,7 @@ class ProductDataMapperPluginTest extends TestCase
 {
     private $product;
     private $extensionAttributes;
+    private $specialPriceMapping;
     private $specialPrice;
     private $subject;
     private $plugin;
@@ -29,6 +31,9 @@ class ProductDataMapperPluginTest extends TestCase
     {
         $om = new ObjectManager($this);
 
+        /**
+         * BEGIN CREATION OF MOCK CLASSES.
+         */
         $this->product = $this
             ->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -40,8 +45,14 @@ class ProductDataMapperPluginTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->specialPrice = $this
-            ->getMockBuilder(SpecialPriceInterface::class)
+        /**
+         * This class will be used for getting/setting data.
+         * @see \SnowIO\ExtendedProductRepositoryEE\Test\Unit\Plugin\Model\ProductDataMapperPluginTest::testMapProductDataWithPayloads
+         */
+        $this->specialPrice = new SpecialPriceFixture();
+
+        $this->specialPriceMapping = $this
+            ->getMockBuilder(SpecialPriceMapping::class)
             ->setMethods([
                 'setPrice',
                 'setStoreId',
@@ -76,9 +87,12 @@ class ProductDataMapperPluginTest extends TestCase
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMock();
+        /**
+         * END CREATION OF MOCK CLASSES.
+         */
 
+        // Create subject class required in constructor for plugin class.
         $this->subject = $om->getObject(ProductDataMapper::class);
-        $this->plugin = new Plugin($this->stagingSpecialPriceModel, $this->storeRepository);
     }
 
     /**
@@ -93,31 +107,8 @@ class ProductDataMapperPluginTest extends TestCase
             ->method('getExtensionAttributes')
             ->willReturn(null);
 
-        $result = $this->plugin->aroundMapProductDataForSave(
-            $this->subject,
-            $this->mockProceedForPlugin(),
-            $this->product
-        );
-
-        $this->assertNull($result);
-    }
-
-    /**
-     * Test that a product with extension attributes, but without special price extension attribute does nothing.
-     *
-     * @author Liam Toohey (lt@amp.co)
-     */
-    public function testMapProductDataForSaveNoSpecialPriceExtensionAttribute()
-    {
-        $this->extensionAttributes
-            ->expects($this->any())
-            ->method('getSpecialPrice')
-            ->willReturn(null);
-
-        $this->product
-            ->expects($this->any())
-            ->method('getExtensionAttributes')
-            ->willReturn($this->extensionAttributes);
+        // Create actual testable class
+        $this->plugin = new Plugin($this->stagingSpecialPriceModel, $this->storeRepository, $this->specialPrice);
 
         $result = $this->plugin->aroundMapProductDataForSave(
             $this->subject,
@@ -126,88 +117,77 @@ class ProductDataMapperPluginTest extends TestCase
         );
 
         $this->assertNull($result);
-    }
-
-    /**
-     * Test that a product with an invalid special price payload throws exception.
-     *
-     * @author Liam Toohey (lt@amp.co)
-     */
-    public function testMapProductDataForSaveInvalidPayload()
-    {
-        $this->specialPrice
-            ->expects($this->any())
-            ->method('getPrice')
-            ->willReturn(null);
-
-        $this->extensionAttributes
-            ->expects($this->any())
-            ->method('getSpecialPrice')
-            ->willReturn([$this->specialPrice]);
-
-        $this->product
-            ->expects($this->any())
-            ->method('getExtensionAttributes')
-            ->willReturn($this->extensionAttributes);
-
-        $this->expectException(LocalizedException::class);
-
-        $this->plugin->aroundMapProductDataForSave(
-            $this->subject,
-            $this->mockProceedForPlugin(),
-            $this->product
-        );
     }
 
     /**
      * Test that a product valid special price payload returns null (void method).
      *
      * @author Liam Toohey (lt@amp.co)
+     * @dataProvider dataForAroundMapProductDataForSave
      */
-    public function testMapProductDataForSaveValidPayload()
+    public function testMapProductDataWithPayloads(
+        $price,
+        $storeId,
+        $actualStoreId,
+        $sku,
+        $priceFrom,
+        $priceTo,
+        $expected
+    )
     {
-        $this->specialPrice
-            ->expects($this->once())
+        $this->specialPriceMapping
+            ->expects($this->any())
             ->method('getPrice')
-            ->willReturn(10.00);
+            ->willReturn($price);
 
-        $this->specialPrice
+        $this->specialPriceMapping
             ->expects($this->any())
             ->method('getStoreId')
-            ->willReturn("ms_uk");
+            ->willReturn($storeId);
 
-        $this->specialPrice
-            ->expects($this->once())
+        $this->specialPriceMapping
+            ->expects($this->any())
             ->method('getSku')
-            ->willReturn('SKUTEST');
+            ->willReturn($sku);
 
-        $this->specialPrice
-            ->expects($this->once())
+        $this->specialPriceMapping
+            ->expects($this->any())
             ->method('getPriceFrom')
-            ->willReturn('2018-12-12 13:48:05');
+            ->willReturn($priceFrom);
 
-        $this->specialPrice
-            ->expects($this->once())
+        $this->specialPriceMapping
+            ->expects($this->any())
             ->method('getPriceTo')
-            ->willReturn('2018-12-19 00:00:00');
+            ->willReturn($priceTo);
 
         $this->extensionAttributes
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getSpecialPrice')
-            ->willReturn([$this->specialPrice]);
+            ->willReturn([$this->specialPriceMapping]);
 
         $this->product
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getExtensionAttributes')
             ->willReturn($this->extensionAttributes);
 
-        $this->store
-            ->expects($this->once())
-            ->method('getId')
-            ->willReturn("1");
+        /**
+         * Actual store id is set from data provider if payload includes store code instead of store id.
+         * We need to mock that the store id actually gets set to the special price, not the code.
+         */
+        if(!is_null($actualStoreId)) {
+            $this->store
+                ->expects($this->any())
+                ->method('getId')
+                ->willReturn($actualStoreId);
+
+            $this->specialPriceMapping
+                ->expects($this->any())
+                ->method('getStoreId')
+                ->willReturn($actualStoreId);
+        }
 
         $this->storeRepository
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('get')
             ->willReturn($this->store);
 
@@ -216,14 +196,16 @@ class ProductDataMapperPluginTest extends TestCase
          * If we make it to this call, the payload is valid and this function should return true.
          */
         $this->stagingSpecialPriceModel
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('update')
             ->willReturn(true);
 
-        /**
-         * Re-instantiate plugin class to include amended store repository mock.
-         */
-        $this->plugin = new Plugin($this->stagingSpecialPriceModel, $this->storeRepository);
+        // Create actual testable class
+        $this->plugin = new Plugin($this->stagingSpecialPriceModel, $this->storeRepository, $this->specialPrice);
+
+        if ($expected === LocalizedException::class) {
+            $this->expectException(LocalizedException::class);
+        }
 
         $result = $this->plugin->aroundMapProductDataForSave(
             $this->subject,
@@ -235,6 +217,45 @@ class ProductDataMapperPluginTest extends TestCase
          * Successful calls to aroundMapProductDataForSave return void.
          */
         $this->assertEquals(null, $result);
+    }
+
+    public function dataForAroundMapProductDataForSave()
+    {
+        return [
+            'Invalid payload' => [
+                $price = null,
+                $storeId = null,
+                $actualStoreId = null,
+                $sku = null,
+                $priceFrom = null,
+                $priceTo = null,
+                $expected = LocalizedException::class
+            ],
+            'Valid payload with store code' => [
+                $price = '10.00',
+                // Store ID will likely be store code as we only have code in mappings.
+                $storeId = 'ms_uk',
+                // This is the actual store ID loaded from Magento, using the store code.
+                $actualStoreId = '1',
+                $sku = 'TEST01',
+                $priceFrom = '2020-12-04 13:48:05',
+                $priceTo = '2020-12-07 00:00:00',
+                // Successful calls to aroundMapProductDataForSave return void.
+                $expected = null
+            ],
+            'Valid payload with store id' => [
+                $price = '10.00',
+                // Also handle cases where correct store id is passed in payload.
+                $storeId = '1',
+                // Actual store ID not loaded as store ID passes in payload.
+                $actualStoreId = null,
+                $sku = 'TEST01',
+                $priceFrom = '2020-12-04 13:48:05',
+                $priceTo = '2020-12-07 00:00:00',
+                // Successful calls to aroundMapProductDataForSave return void.
+                $expected = null
+            ],
+        ];
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,4 +3,5 @@
     <type name="SnowIO\ExtendedProductRepository\Model\ProductDataMapper">
         <plugin name="ExtendedProductRepositoryDataMapperPlugin" type="SnowIO\ExtendedProductRepositoryEE\Plugin\Model\ProductDataMapperPlugin" disabled="false"/>
     </type>
+    <preference for="SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface" type="SnowIO\ExtendedProductRepositoryEE\Model\SpecialPriceMapping" />
 </config>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,4 +1,5 @@
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd"><extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
-        <attribute code="special_price" type="Magento\Catalog\Api\Data\SpecialPriceInterface[]" />
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
+        <attribute code="special_price" type="SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface[]" />
     </extension_attributes>
 </config>


### PR DESCRIPTION
Amend plugin to accept both integer and string from store_id payload
---------------

**Payload parameter `store_id`/`store_code` as string:**

This PR aims to ensure we can accept both a string value and an integer value for `store_id` payload. To do this, I have had to create a new interface for the special price payload. This interface differs from the vanilla special price interface as it accepts `store_id` as string and not an integer. 

By accepting the `store_id` as a string, it means we can post either the actual store id or the store code in the `store_id` payload request. We can then use PHP to decide whether the `store_code` or `store_id` have been sent, and work accordingly.

**Create `SpecialPriceInterface` instances from custom `SpecialPriceMappingInterface` data:**

The new class we have created in order to accept `store_id` as string will not be accepted in the vanilla functions used to update special prices. This means we need to create `SpecialPriceInterface` instances from our `SpecialPriceMappingInterface` data. Once we have created these instances, we can pass them into the vanilla special price update function.