### PR TITLE
Ignore 0 prices in special price payload

### DIFF
--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -76,7 +76,12 @@ class ProductDataMapperPlugin
         $specialPrices = [];
         /** @var \SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface $price */
         foreach ($prices as $price) {
+
             if (!$this->validatePricePayload($price)) {
+                if ($price->getPrice() === (float)0) {
+                    // Ignore 0 prices
+                    continue;
+                }
                 throw new LocalizedException(new Phrase(
                     'Missing data from special_price extension attribute payload'
                 ));

--- a/Plugin/Model/ProductDataMapperPlugin.php
+++ b/Plugin/Model/ProductDataMapperPlugin.php
@@ -76,7 +76,6 @@ class ProductDataMapperPlugin
         $specialPrices = [];
         /** @var \SnowIO\ExtendedProductRepositoryEE\Api\Data\SpecialPriceMappingInterface $price */
         foreach ($prices as $price) {
-
             if (!$this->validatePricePayload($price)) {
                 if ($price->getPrice() === (float)0) {
                     // Ignore 0 prices


### PR DESCRIPTION
We do not want to throw an exception for special price payloads containing a price of `0`. Instead, we want to just ignore these special prices.