### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=7",
-        "magento/framework": "^100|^101",
-        "magento/module-catalog": "^101|^102",
+        "magento/framework": "^100|^101|^102",
+        "magento/module-catalog": "^101|^102|^103",
         "magento/module-catalog-staging": "^100.2.2",
         "snowio/magento2-extended-product-repository": "^2.2.1"
     },


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. No additional modifications were needed