### PR TITLE
Fix integration test support

### DIFF
--- a/Observer/EntitySaveAfter.php
+++ b/Observer/EntitySaveAfter.php
@@ -5,14 +5,14 @@ namespace SnowIO\ExtendedProductRepositoryEE\Observer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
-use SnowIO\ExtendedProductRepositoryEE\Model\SpecialPriceScheduler;
+use SnowIO\ExtendedProductRepositoryEE\Model\SpecialPriceScheduler\Proxy as SpecialPriceSchedulerProxy;
 
 class EntitySaveAfter implements ObserverInterface
 {
     /** @var SpecialPriceScheduler  */
     protected $specialPriceScheduler;
 
-    public function __construct(SpecialPriceScheduler $specialPriceScheduler)
+    public function __construct(SpecialPriceSchedulerProxy $specialPriceScheduler)
     {
         $this->specialPriceScheduler = $specialPriceScheduler;
     }


### PR DESCRIPTION
Prevent eager instantiation of this which causes the following setup error in integration tests

```
[Progress: 806 / 1573]
Module 'Magento_Cms':
In PatchApplier.php line 170:
  [Magento\Framework\Setup\Exception]
  Unable to apply data patch Magento\Cms\Setup\Patch\Data\CreateDefaultPages
  for module Magento_Cms. Original exception message: Invalid entity_type spe
  cified: catalog_product
```

See branch with name `1-3-1` for same fix for the 1.3 series